### PR TITLE
Mostly Readme additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,8 @@ Yeoman generator to scaffold the test folder structure for our webapps.
 
 ### Troubleshooting
 
-Make sure your `node -v` and `nodenv global` are >4.0.0 as Yeoman has issues with lesser versions.
+We use `nodenv` to manage our Node.js versions. There can be a globally used version, which should be >4.0.0 as of Feb '16 (type `nodenv global` at the command line to check), and also versions specific to the project you are working on, which are indicated by the presence of a `.node-version` file in the project root and which can be verified by typing `nodenv local` at the command line.
+
+* The generator makes extensive use of Node's `path.parse()` method, which was added in Node version 12. So make sure that **`nodenv local` version is >0.12**.
+
+* **Node versions should match between where you installed the generator and the proejct**. Is the generator installed on this version of Node? Type `yo --help` within the project to see. If it's not, go back to the `generator-jasmine-test` root directory, change the `nodenv` version to match the project's (`nodenv local x.x.x`) and reinstall the generator (`npm i` followed by `npm link`). It should now run.

--- a/README.md
+++ b/README.md
@@ -1,30 +1,41 @@
 # Jasmine Test Generator
 
-Supports both JS and PHP tests
+Supports both JS and PHP tests.
 
-0. Clone this directory: ensure it goes into a folder called `generator-jasmine-test` as Yeoman relies on the file system to find available generators. 
+Yeoman generator to scaffold the test folder structure for our webapps.
 
-1. Install Yeoman:
+## Install Yeoman
 
+* Use npm to install Yeoman:
+
+    ``` 
+    npm install -g yo
     ```
-    npm install -g yo bower grunt-cli gulp
-    ```
+    
+## Install the generator
 
-2. Install the generator's dependencies if they are not already installed. From within the `generator-jasmine-test` folder:
+* Clone this directory: ensure it goes into a folder called `generator-jasmine-test` as Yeoman relies on the file system to find available generators. It doesn't need to be within the project that you want to use it on, in fact, it shouldn't be!
+
+
+* Install the generator's dependencies if they are not already installed. From within your new `generator-jasmine-test` folder:
 
     ```
     npm install
     ```
 
-3. npm link the node module from inside the `generator-jasmine-test` directory.
+* npm link the generator from inside the `generator-jasmine-test` directory.
 
     ```
     npm link
     ```
 
-4. Place `.yo-rc.json` file at the root of the project you want to test. It will need to have an empty object `{}` inside of it.
+## Set up project for use with Yeoman
 
-5. Go into the directory of the file you want to test and do:
+* Place `.yo-rc.json` file at the root of the project you want to test. It will need to have an empty object `{}` inside of it.
+
+## Create the files
+
+* Go into the directory of the file you want to test and do:
 
     ```
     yo jasmine-test file-you-want-to-test.js
@@ -32,4 +43,8 @@ Supports both JS and PHP tests
 
   * Additionally you can be in another location within the project when you do this, as long as you pass a path to the `file-you-want-to-test.js` that's relative to your current location.
 
-6. Add `--config` if you want a config file to be created.
+* Add `--config` to the end of the `yo` command if you want a config file to be created.
+
+### Troubleshooting
+
+Make sure your `node -v` and `nodenv global` are >4.0.0 as Yeoman has issues with lesser versions.

--- a/README.md
+++ b/README.md
@@ -2,19 +2,34 @@
 
 Supports both JS and PHP tests
 
-1) Install yeoman 
+0. Clone this directory: ensure it goes into a folder called `generator-jasmine-test` as Yeoman relies on the file system to find available generators. 
 
-`npm install -g yo bower grunt-cli gulp`
+1. Install Yeoman:
 
+    ```
+    npm install -g yo bower grunt-cli gulp
+    ```
 
-2) Place .yo-rc.json file at the root of the project you want to test. It will need to have and empty object {} inside of it.
+2. Install the generator's dependencies if they are not already installed. From within the `generator-jasmine-test` folder:
 
-3) npm link the node module
+    ```
+    npm install
+    ```
 
-`npm link`
+3. npm link the node module from inside the `generator-jasmine-test` directory.
 
-4) Go into the directory of the file you want to test and do
+    ```
+    npm link
+    ```
 
-`yo jasmine-test file-you-want-to-test.js`
+4. Place `.yo-rc.json` file at the root of the project you want to test. It will need to have an empty object `{}` inside of it.
 
-5) Add `--config` if you want a config file to be created
+5. Go into the directory of the file you want to test and do:
+
+    ```
+    yo jasmine-test file-you-want-to-test.js
+    ```
+
+  * Additionally you can be in another location within the project when you do this, as long as you pass a path to the `file-you-want-to-test.js` that's relative to your current location.
+
+6. Add `--config` if you want a config file to be created.

--- a/app/index.js
+++ b/app/index.js
@@ -2,6 +2,8 @@ var generators = require('yeoman-generator');
 var path = require('path');
 var mkdirp = require('mkdirp');
 var fs = require('fs');
+var chalk = require('chalk');
+
 module.exports = generators.Base.extend({
     constructor: function() {
         this.realCWD = process.cwd();
@@ -74,7 +76,7 @@ module.exports = generators.Base.extend({
     _directoryCheck: function(path) {
         fs.stat(path, function(err, stat) {
             if (err !== null) {
-                console.log('Cant find file');
+                console.log(chalk.bold.red('Can\'t find file'));
                 process.exit();
             }
         });
@@ -89,5 +91,5 @@ module.exports = generators.Base.extend({
             this.pathObject.base;
 
         this.fs.write(testPath, 'PHP test');
-    },
+    }
 });

--- a/app/index.js
+++ b/app/index.js
@@ -1,5 +1,7 @@
 var generators = require('yeoman-generator');
 var path = require('path');
+// Fix for Node 0.10.x that doesn't have path.parse
+var pathParse = require('path-parse');
 var mkdirp = require('mkdirp');
 var fs = require('fs');
 var chalk = require('chalk');
@@ -21,7 +23,7 @@ module.exports = generators.Base.extend({
 
         this._directoryCheck(filePath);
 
-        this.pathObject = path.parse(filePath);
+        this.pathObject = pathParse(filePath);
 
         this.subTestFolders = ['Spec', 'Setup', 'Config'];
 

--- a/app/templates/Spec.js
+++ b/app/templates/Spec.js
@@ -1,11 +1,11 @@
 describe('Write a test suite', function() {
 
     beforeEach(function() {
-
+        // Do something before each test is run
     });
 
     it('Write a spec', function() {
-
+        expect(true).toEqual(true);
     });
 
 });

--- a/package.json
+++ b/package.json
@@ -9,10 +9,8 @@
     "app"
   ],
   "dependencies": {
-    "gulp-jasmine": "^2.2.1",
     "mkdirp": "^0.5.1",
     "path": "^0.12.7",
-    "process": "^0.11.2",
-    "yeoman-generator": "^0.20.2"
+    "yeoman-generator": "^0.22.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "mkdirp": "^0.5.1",
-    "path": "^0.12.7",
+    "path-parse": "^1.0.5",
     "yeoman-generator": "^0.22.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "app"
   ],
   "dependencies": {
+    "chalk": "^1.1.1",
     "mkdirp": "^0.5.1",
     "path": "^0.12.7",
     "yeoman-generator": "^0.22.5"


### PR DESCRIPTION
Decided not to create an additional init method as most of the time the generator is used will be to scaffold tests and not to create the `.yo-rs.json` folder. If the user hasn't followed the instructions in the Readme and created the file then that's their fault!

Regarding the node versions: it can't be run on <0.12 as it uses the `path.parse()` method which was introduced in this version. Perhaps there is some way to warn the user about this?

It isn't true that it needs Node.js versions >4.0.0, just that the generator is installed on the version of Node that that project uses (that is often set in `.node-version`. I have made a Troubleshooting section in the Readme to explain this.

The other changes are window-dressing: making console.log() messages coloured and putting a dummy spec in `Spec.js`.
