### PR TITLE
Adding tests and an error callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 tmp
+coverage

--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ Yeoman generator to scaffold the test folder structure for our webapps.
 
 We use `nodenv` to manage our Node.js versions. There can be a globally used version, which should be >4.0.0 as of Feb '16 (type `nodenv global` at the command line to check), and also versions specific to the project you are working on, which are indicated by the presence of a `.node-version` file in the project root and which can be verified by typing `nodenv local` at the command line.
 
-* The generator makes extensive use of Node's `path.parse()` method, which was added in Node version 12. So make sure that **`nodenv local` version is >0.12**.
+* The generator makes extensive use of Node's `path.parse()` method, which was added in Node version 12. The `path-parse` package is a polyfill for users with <v0.12 that falls back to the native method if it exists.
 
 * **Node versions should match between where you installed the generator and the proejct**. Is the generator installed on this version of Node? Type `yo --help` within the project to see. If it's not, go back to the `generator-jasmine-test` root directory, change the `nodenv` version to match the project's (`nodenv local x.x.x`) and reinstall the generator (`npm i` followed by `npm link`). It should now run.

--- a/README.md
+++ b/README.md
@@ -52,3 +52,9 @@ We use `nodenv` to manage our Node.js versions. There can be a globally used ver
 * The generator makes extensive use of Node's `path.parse()` method, which was added in Node version 12. The `path-parse` package is a polyfill for users with <v0.12 that falls back to the native method if it exists.
 
 * **Node versions should match between where you installed the generator and the proejct**. Is the generator installed on this version of Node? Type `yo --help` within the project to see. If it's not, go back to the `generator-jasmine-test` root directory, change the `nodenv` version to match the project's (`nodenv local x.x.x`) and reinstall the generator (`npm i` followed by `npm link`). It should now run.
+
+## Run the tests
+
+Clone the project, install all the dependencies with `npm install`, the run `npm test`.
+
+Generate coverage reports with `npm run cover`.

--- a/app/index.js
+++ b/app/index.js
@@ -1,6 +1,7 @@
+'use strict';
+
 var generators = require('yeoman-generator');
 var path = require('path');
-// Fix for Node 0.10.x that doesn't have path.parse
 var pathParse = require('path-parse');
 var mkdirp = require('mkdirp');
 var fs = require('fs');

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "keywords": [
     "yeoman-generator"
   ],
+  "scripts": {
+    "test": "mocha --reporter spec",
+    "cover": "node_modules/istanbul/lib/cli.js cover node_modules/mocha/bin/_mocha -- -R spec test/*"
+  },
   "files": [
     "app"
   ],
@@ -13,5 +17,12 @@
     "mkdirp": "^0.5.1",
     "path-parse": "^1.0.5",
     "yeoman-generator": "^0.22.5"
+  },
+  "devDependencies": {
+    "istanbul": "^0.4.2",
+    "mocha": "^2.4.5",
+    "sinon": "^1.17.3",
+    "yeoman-assert": "^2.0.0",
+    "yeoman-test": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "yeoman-generator": "^0.22.5"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5",
     "sinon": "^1.17.3",
+    "sinon-chai": "^2.8.0",
     "yeoman-assert": "^2.0.0",
     "yeoman-test": "^1.0.0"
   }

--- a/test/app.js
+++ b/test/app.js
@@ -9,6 +9,7 @@ describe('generator-jasmine-test:app', function () {
     
     describe('without config', function() {
         before(function(done) {
+            // need to stub in order for _directoryCheck() to run 
             sinon.stub(fs, 'stat');
             
             helpers.run(path.join(__dirname, '../app'))
@@ -16,7 +17,12 @@ describe('generator-jasmine-test:app', function () {
                 .on('end', done);
         });
         
-        it('creates Spec and Setup files', function (done) {
+        after(function() {
+            // unwrap Sinon stubbed method
+            fs.stat.restore(); 
+        });
+        
+        it('creates Spec and Setup files', function () {
             assert.file([
                 'tests/jasmine_tests/spec/indexTest/indexSpec.js',
                 'tests/jasmine_tests/spec/indexTest/indexSetup.js'
@@ -24,8 +30,10 @@ describe('generator-jasmine-test:app', function () {
             assert.noFile([
                 'tests/jasmine_tests/spec/indexTest/indexConfig.js'
             ]);
-            fs.stat.restore(); 
-            done();
+            assert.fileContent('tests/jasmine_tests/spec/indexTest/indexSpec.js',
+                                /describe\('Write a test suite', function\(\) \{/);
+            assert.fileContent('tests/jasmine_tests/spec/indexTest/indexSetup.js',
+                                /\/\/ This will run before your tests/);
         });
         
     });
@@ -40,17 +48,24 @@ describe('generator-jasmine-test:app', function () {
                 .on('end', done);
         });
         
+        after(function() {
+            fs.stat.restore(); 
+        });
         
-        it('creates Spec, Seup and Config files', function (done) {
+        it('creates Spec, Setup and Config files', function () {
             assert.file([
                 'tests/jasmine_tests/spec/indexTest/indexSpec.js',
                 'tests/jasmine_tests/spec/indexTest/indexSetup.js',
                 'tests/jasmine_tests/spec/indexTest/indexConfig.js'
             ]);
-            fs.stat.restore(); 
-            done();
+            assert.fileContent('tests/jasmine_tests/spec/indexTest/indexSpec.js',
+                                /describe\('Write a test suite', function\(\) \{/);
+            assert.fileContent('tests/jasmine_tests/spec/indexTest/indexSetup.js',
+                                /\/\/ This will run before your tests/);
+            assert.fileContent('tests/jasmine_tests/spec/indexTest/indexConfig.js',
+                                /var filePath = srcDirectory \+ '\/index\.js';/);
+            
         });
     });
-    
-    //assert file contents
+
 });

--- a/test/app.js
+++ b/test/app.js
@@ -1,0 +1,56 @@
+'use strict';
+var path = require('path');
+var assert = require('yeoman-assert');
+var helpers = require('yeoman-test');
+var sinon = require('sinon');
+var fs = require('fs');
+
+describe('generator-jasmine-test:app', function () {
+    
+    describe('without config', function() {
+        before(function(done) {
+            sinon.stub(fs, 'stat');
+            
+            helpers.run(path.join(__dirname, '../app'))
+                .withArguments(['index.js'])
+                .on('end', done);
+        });
+        
+        it('creates Spec and Setup files', function (done) {
+            assert.file([
+                'tests/jasmine_tests/spec/indexTest/indexSpec.js',
+                'tests/jasmine_tests/spec/indexTest/indexSetup.js'
+            ]);
+            assert.noFile([
+                'tests/jasmine_tests/spec/indexTest/indexConfig.js'
+            ]);
+            fs.stat.restore(); 
+            done();
+        });
+        
+    });
+    
+    describe('with config', function() {
+        before(function(done) {
+            sinon.stub(fs, 'stat');
+            
+            helpers.run(path.join(__dirname, '../app'))
+                .withArguments(['index.js'])
+                .withOptions({config: true})
+                .on('end', done);
+        });
+        
+        
+        it('creates Spec, Seup and Config files', function (done) {
+            assert.file([
+                'tests/jasmine_tests/spec/indexTest/indexSpec.js',
+                'tests/jasmine_tests/spec/indexTest/indexSetup.js',
+                'tests/jasmine_tests/spec/indexTest/indexConfig.js'
+            ]);
+            fs.stat.restore(); 
+            done();
+        });
+    });
+    
+    //assert file contents
+});

--- a/test/app.js
+++ b/test/app.js
@@ -2,7 +2,13 @@
 var path = require('path');
 var assert = require('yeoman-assert');
 var helpers = require('yeoman-test');
+// These are mostly for testing console.log output
 var sinon = require('sinon');
+var chai = require('chai');
+var expect = require('chai').expect;
+var sinonChai = require("sinon-chai");
+chai.use(sinonChai);
+
 var fs = require('fs');
 
 describe('generator-jasmine-test:app', function () {
@@ -65,6 +71,33 @@ describe('generator-jasmine-test:app', function () {
             assert.fileContent('tests/jasmine_tests/spec/indexTest/indexConfig.js',
                                 /var filePath = srcDirectory \+ '\/index\.js';/);
             
+        });
+    });
+
+    describe('File does not exist', function() {
+        var log;
+
+        before(function(done) {
+            // First stub out console.log so we can record what's printed out
+            log = console.log;
+            // fix so that Mocha reporter still outputs stuff to console
+            sinon.stub(console, 'log', function() {
+              return log.apply(log, arguments);
+            });
+
+            helpers.run(path.join(__dirname, '../app'))
+                .withArguments(['index.js'])
+                .on('end', done);
+        });
+
+        it('logs a message to the user', function() {
+            assert.noFile([
+                'tests/jasmine_tests/spec/indexTest/indexSpec.js',
+                'tests/jasmine_tests/spec/indexTest/indexSetup.js',
+                'tests/jasmine_tests/spec/indexTest/indexConfig.js'
+            ]);
+            expect(console.log).to.have.been.called;
+            expect(console.log).to.have.been.calledWith("Error: directory does not exist");
         });
     });
 


### PR DESCRIPTION
- Beautiful tests
- npm scripts to run beautiful tests & coverage
- An error callback for `_directoryCheck()` that will cause the app to exit if the directory doesn't exist (feels a bit hacky with setting and checking the variable but it's the best I could do to stop the `wiring()` function from running
